### PR TITLE
One repository rule, discord bot fix, readme requirements, poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ A shipped project must be shared in a way that other people can experience to th
 <details>
 <summary>Fine Print</summary>
 <ul>
+<li>Your project must have its own repo</li>
 <li>Your repo needs a README</li>
 <li>Ships must be shared in the Hack Club Slack with a post in #scrapbook. They also need a screenshot or video or URL to experience the thing</li>
 <li>There must be a component of the ship that can be experienced by people in Slack</li>
@@ -116,6 +117,7 @@ Some examples of "native" websites diffferent types of projects are below. Keep 
     - https://top.gg
     - https://bots.ondiscord.xyz
     - https://discord.bots.gg
+    - Invite link to your bot
 
 ## Python Projects
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ In particular we find python projects are often the hardest to ship. A couple ap
 
 - If you have a package, you can publish it to PyPi
 - If you make a game or executable, you can publish it with pygame or pyinstaller
-- If all else fails, you can publish it to GitHub and include a `requirements.txt` file & a `poetry.lock` file & cut a release
+- If all else fails, you can publish it to GitHub and include a `requirements.txt` file | a `poetry.lock` file & make sure to cut a release
 
 Many python projects end up being just a `script.py` file in a repo, which isn't a real project because it may only work on your machine. Keep in mind that the goal is to make your project accessible to others & everyone has different versions of python and different dependencies installed.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ A shipped project must be shared in a way that other people can experience to th
 <summary>Fine Print</summary>
 <ul>
 <li>Your project must have its own repo</li>
-<li>Your repo needs a README</li>
+<li>Your repo needs a README with clear steps on how to experience your project and with any form of demo (screenshots, videos, links)</li>
 <li>Ships must be shared in the Hack Club Slack with a post in #scrapbook. They also need a screenshot or video or URL to experience the thing</li>
 <li>There must be a component of the ship that can be experienced by people in Slack</li>
 <li>For digital but non-code projects, a file—and, for some online tools, a link—of the "most native" type for the project must be included. STL and .blend for Blender, PNG and project link for Figma, Gerber file and CAD file for PCBs, STEP export and STL for CAD (with a link for OnShape projects), PNG for and source file (PSD, XCF, etc) for digital art…</li>


### PR DESCRIPTION
Added clarification about one repository per project rule, fixed discord bot deployment - it takes 1-2 weeks to deploy it on the website, so invite link should be fine. Also updated the README rule